### PR TITLE
feat: renovate best-practices, 7-day cooldown

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,13 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended",
-    "helpers:pinGitHubActionDigestsToSemver",
-    "helpers:githubDigestChangelogs"
+    "config:best-practices"
   ],
   "dependencyDashboard": true,
   "enabledManagers": ["gradle", "github-actions"],
   "separateMinorPatch": true,
+  "minimumReleaseAge": "7 days",
   "packageRules": [
     {
       "description": "Automerge safe dependency updates after CI passes",


### PR DESCRIPTION
- Switch from `config:recommended` + individual helpers to `config:best-practices`
- Add `minimumReleaseAge: 7 days` cooldown
- pinact confirmed actions already pinned with correct annotations