### PR TITLE
fix: correctness bugs and code quality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased] — v0.5.2
+
+### Fixed
+- `KafkaService`: restore thread interrupt flag in all 10 `InterruptedException` catch sites — previously swallowed, breaking cooperative cancellation
+- `KafkaService`: `updateTopicReplication` reuses existing `AdminClient` instead of opening a second connection
+- `KafkaService`: add upfront validation for null/negative replication factor in `updateTopicReplication`
+- `KafkaService`: fix `addTopicPartition` guard (`<= 1` → `< 1`)
+- `ApplyManager`: skip `NO_CHANGE` topic config plans to prevent spurious `incrementalAlterConfigs` API calls on every apply
+- `PlanManager`: fix `FileWriter` resource leak in `writePlanToFile` — use try-with-resources, remove redundant `createNewFile()`
+- `PlanManager`: guard against empty partition list before `.get(0)` — throws `ValidationException` with context instead of `IndexOutOfBoundsException`
+- `StateManager`: replace unsafe `orElseGet(defaultPartitions::get)` with `orElseThrow(ValidationException)` for missing defaults
+- Fix typos in user-facing error messages: `increate` → `increase`, `enougth` → `enough`, `newReasignement` → `newReassignment`
+- Make static loggers `final` in `PlanManager`, `KafkaService`, `StateManager`
+
+### Tests
+- Add unit tests for empty-partition `ValidationException`, invalid replication guard, and `addTopicPartition` guard
+- Uncomment `cleanupSpec` in `PlanCommandIntegrationSpec` to prevent cluster state leaks between runs
+
+## [0.5.1] - 2026-03-25
+
+### Added
+- Manage schema registry subjects from desired state
+
+### Fixed
+- Stabilize cluster cleanup between integration runs
+
+### Changed
+- Publish releases with a single `action-gh-release` step
+
+## [0.5.0] - 2026-03-25
+
+### Added
+- Cluster import command
+- Kafka broker compatibility matrix (3.x and 4.x)
+
+### Fixed
+- Make stale topic add plans idempotent
+- Custom user ACLs planner regression
+
+### Changed
+- Pin action SHAs and switch to Renovate
+- Port upstream topic planning improvements
+
+## [0.4.0] - 2026-03-24
+
+### Added
+- Hardened CLI and config-loading path — invalid input, unreadable `--command-config` files, and incomplete SASL config fail fast
+- Tightened validation for desired state: topic definitions require `partitions >= 1` and `replication >= 1`, unresolved custom ACL owners rejected pre-flight
+
+### Fixed
+- Topic replication decreases now properly rejected
+- Kafka Streams internal topic handling with custom `application-id`
+- Duplicate ACL generation
+- Release packaging path for versioned shadow JAR
+
+## [0.3.1] - 2026-03-23
+
+See [0.3.0...0.3.1](https://github.com/chenrui333/kafka-gitops/compare/0.3.0...0.3.1)
+
+## [0.3.0] - 2026-03-23
+
+Initial tracked release.
+
+[Unreleased]: https://github.com/chenrui333/kafka-gitops/compare/0.5.1...HEAD
+[0.5.1]: https://github.com/chenrui333/kafka-gitops/compare/0.5.0...0.5.1
+[0.5.0]: https://github.com/chenrui333/kafka-gitops/compare/0.4.0...0.5.0
+[0.4.0]: https://github.com/chenrui333/kafka-gitops/compare/0.3.1...0.4.0
+[0.3.1]: https://github.com/chenrui333/kafka-gitops/compare/0.3.0...0.3.1
+[0.3.0]: https://github.com/chenrui333/kafka-gitops/releases/tag/0.3.0

--- a/src/main/java/com/devshawn/kafka/gitops/StateManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/StateManager.java
@@ -61,7 +61,7 @@ import java.io.IOException;
 
 public class StateManager {
 
-    private static org.slf4j.Logger log = LoggerFactory.getLogger(StateManager.class);
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(StateManager.class);
 
     private final ManagerConfig managerConfig;
     private final ObjectMapper objectMapper;
@@ -333,8 +333,12 @@ public class StateManager {
         Optional<Integer> defaultReplication = StateUtil.fetchReplication(desiredStateFile);
 
         desiredStateFile.getTopics().forEach((name, details) -> {
-            Integer partitions = details.getPartitions().orElseGet(defaultPartitions::get);
-            Integer replication = details.getReplication().orElseGet(defaultReplication::get);
+            Integer partitions = details.getPartitions()
+                    .or(() -> defaultPartitions)
+                    .orElseThrow(() -> new ValidationException("partitions not set for topic: " + name));
+            Integer replication = details.getReplication()
+                    .or(() -> defaultReplication)
+                    .orElseThrow(() -> new ValidationException("replication not set for topic: " + name));
 
             desiredState.putTopics(name, new TopicDetails.Builder()
                     .mergeFrom(details)

--- a/src/main/java/com/devshawn/kafka/gitops/manager/ApplyManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/manager/ApplyManager.java
@@ -52,7 +52,9 @@ public class ApplyManager {
                         kafkaService.updateTopicReplication(clusterNodes, topicPlan.getName(), topicDetailsPlan.getReplication().get());
                     }
                 }
-                topicPlan.getTopicConfigPlans().forEach(topicConfigPlan -> applyTopicConfiguration(topicPlan, topicConfigPlan));
+                topicPlan.getTopicConfigPlans().stream()
+                        .filter(c -> c.getAction() != PlanAction.NO_CHANGE)
+                        .forEach(topicConfigPlan -> applyTopicConfiguration(topicPlan, topicConfigPlan));
                 LogUtil.printPostApply();
             } else if (topicPlan.getAction() == PlanAction.REMOVE && !managerConfig.isDeleteDisabled()) {
                 LogUtil.printTopicPreApply(topicPlan);
@@ -92,7 +94,9 @@ public class ApplyManager {
             });
         });
 
-        topicPlan.getTopicConfigPlans().forEach(topicConfigPlan -> applyTopicConfiguration(topicPlan, topicConfigPlan));
+        topicPlan.getTopicConfigPlans().stream()
+                .filter(c -> c.getAction() != PlanAction.NO_CHANGE)
+                .forEach(topicConfigPlan -> applyTopicConfiguration(topicPlan, topicConfigPlan));
     }
 
     private void applyTopicConfiguration(TopicPlan topicPlan, TopicConfigPlan topicConfigPlan) {

--- a/src/main/java/com/devshawn/kafka/gitops/manager/PlanManager.java
+++ b/src/main/java/com/devshawn/kafka/gitops/manager/PlanManager.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 
 public class PlanManager {
 
-    private static org.slf4j.Logger log = LoggerFactory.getLogger(PlanManager.class);
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(PlanManager.class);
 
     private final ManagerConfig managerConfig;
     private final KafkaService kafkaService;
@@ -78,7 +78,11 @@ public class PlanManager {
             } else {
                 log.info("[PLAN] Topic {} exists, it will not be created.", key);
                 TopicDescription topicDescription = topics.get(key);
-                
+
+                if (topicDescription.partitions().isEmpty()) {
+                    throw new ValidationException("Topic " + key + " has no available partitions; cluster may be degraded.");
+                }
+
                 topicPlan.setAction(PlanAction.NO_CHANGE);
                 topicDetailsPlan.setPartitions(topicDescription.partitions().size())
                     .setReplication(topicDescription.partitions().get(0).replicas().size());
@@ -254,11 +258,10 @@ public class PlanManager {
     public void writePlanToFile(DesiredPlan desiredPlan) {
         if (managerConfig.getPlanFile().isPresent()) {
             try {
-                managerConfig.getPlanFile().get().createNewFile();
                 DesiredPlan outputPlan = managerConfig.isIncludeUnchangedEnabled() ? desiredPlan : desiredPlan.toChangesOnlyPlan();
-                FileWriter writer = new FileWriter(managerConfig.getPlanFile().get());
-                writer.write(objectMapper.writeValueAsString(outputPlan));
-                writer.close();
+                try (FileWriter writer = new FileWriter(managerConfig.getPlanFile().get())) {
+                    writer.write(objectMapper.writeValueAsString(outputPlan));
+                }
             } catch (IOException ex) {
                 throw new WritePlanOutputException(ex.getMessage() + " ('" + managerConfig.getPlanFile().get() + "')");
             }

--- a/src/main/java/com/devshawn/kafka/gitops/service/KafkaService.java
+++ b/src/main/java/com/devshawn/kafka/gitops/service/KafkaService.java
@@ -42,7 +42,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.stream.Collectors;
 
 public class KafkaService {
-    private static org.slf4j.Logger log = LoggerFactory.getLogger(KafkaService.class);
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(KafkaService.class);
 
     private final KafkaGitopsConfig config;
 
@@ -56,7 +56,10 @@ public class KafkaService {
             AccessControlEntryFilter accessFilter = new AccessControlEntryFilter(null, null, AclOperation.ANY, AclPermissionType.ANY);
             AclBindingFilter filter = new AclBindingFilter(resourcePatternFilter, accessFilter);
             return new ArrayList<>(adminClient.describeAcls(filter).values().get());
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to list Kafka ACLs", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to list Kafka ACLs", ex.getMessage());
         }
     }
@@ -64,7 +67,10 @@ public class KafkaService {
     public void createAcl(AclBinding aclBinding) {
         try (final AdminClient adminClient = buildAdminClient()) {
             adminClient.createAcls(Collections.singletonList(aclBinding)).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to create a Kafka ACL", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to create a Kafka ACL", ex.getMessage());
         }
     }
@@ -72,7 +78,10 @@ public class KafkaService {
     public void deleteAcl(AclBinding aclBinding) {
         try (final AdminClient adminClient = buildAdminClient()) {
             adminClient.deleteAcls(Collections.singletonList(aclBinding.toFilter())).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to delete a Kafka ACL", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to delete a Kafka ACL", ex.getMessage());
         }
     }
@@ -83,6 +92,7 @@ public class KafkaService {
             newTopic.configs(topicConfigPlans.stream().collect(Collectors.toMap(TopicConfigPlan::getKey, topicConfigPlan -> topicConfigPlan.getValue().get())));
             adminClient.createTopics(Collections.singletonList(newTopic)).all().get();
         } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
             throw new KafkaExecutionException("Error thrown when attempting to create a Kafka topic", ex.getMessage());
         } catch (ExecutionException ex) {
             if (ex.getCause() instanceof TopicExistsException) {
@@ -97,34 +107,43 @@ public class KafkaService {
     public void deleteTopic(String topicName) {
         try (final AdminClient adminClient = buildAdminClient()) {
             adminClient.deleteTopics(Collections.singletonList(topicName)).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to delete a Kafka topic", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to delete a Kafka topic", ex.getMessage());
         }
     }
     
     public void addTopicPartition(String topicName, int partitions) {
-        if (partitions <= 1) {
-            throw new IllegalArgumentException("partitions cannot be <= 1");
+        if (partitions < 1) {
+            throw new IllegalArgumentException("partitions cannot be < 1");
         }
         try (final AdminClient adminClient = buildAdminClient()) {
             adminClient.createPartitions(Collections.singletonMap(topicName, NewPartitions.increaseTo(partitions))).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
-            throw new KafkaExecutionException("Error thrown when attempting to increate a Kafka topic partition number", ex.getMessage());
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to increase a Kafka topic partition number", ex.getMessage());
+        } catch (ExecutionException ex) {
+            throw new KafkaExecutionException("Error thrown when attempting to increase a Kafka topic partition number", ex.getMessage());
         }
     }
 
     public Collection<Node> describeClusterNodes() {
       try (final AdminClient adminClient = buildAdminClient()) {
           return adminClient.describeCluster().nodes().get();
-      } catch (InterruptedException | ExecutionException ex) {
-        throw new KafkaExecutionException("Error thrown when attempting to retrieve the Kafka cluster nodes list", ex.getMessage());
+      } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+          throw new KafkaExecutionException("Error thrown when attempting to retrieve the Kafka cluster nodes list", ex.getMessage());
+      } catch (ExecutionException ex) {
+          throw new KafkaExecutionException("Error thrown when attempting to retrieve the Kafka cluster nodes list", ex.getMessage());
       }
     }
 
     public void updateTopicReplication(Collection<Node> clusterNodes, String topicName, Integer integer) {
         try (final AdminClient adminClient = buildAdminClient()) {
-            Map<String, TopicDescription> originalTopicDescription = getTopicDescription(Collections.singleton(topicName));
-            Map<TopicPartition, Optional<NewPartitionReassignment>> newReasignement = new HashMap<>();
+            Map<String, TopicDescription> originalTopicDescription = getTopicDescription(Collections.singleton(topicName), adminClient);
+            Map<TopicPartition, Optional<NewPartitionReassignment>> newReassignment = new HashMap<>();
             originalTopicDescription.values().forEach(topicDescription -> {
                 List<TopicPartitionInfo> topicPartitionInfos = topicDescription.partitions();
                 topicPartitionInfos.forEach(topicPartitionInfo -> {
@@ -141,7 +160,7 @@ public class KafkaService {
                         List<Integer> possibleNewNodes = nodesIds.stream().collect(Collectors.toList());
                         possibleNewNodes.removeAll(replicas);
                         if(possibleNewNodes.isEmpty() || (possibleNewNodes.size() < integer - replicas.size())) {
-                            throw new ValidationException("Error thrown when attempting to update a Kafka topic partition replication: not enougth nodes in the cluster");
+                            throw new ValidationException("Error thrown when attempting to update a Kafka topic partition replication: not enough nodes in the cluster");
                         }
                         Collections.shuffle(possibleNewNodes);
                         while (replicas.size() < integer) {
@@ -149,11 +168,14 @@ public class KafkaService {
                         }
                     }
                     NewPartitionReassignment newPartitionReassignment = new NewPartitionReassignment(replicas);
-                    newReasignement.put(topicPartition, Optional.of(newPartitionReassignment) );
+                    newReassignment.put(topicPartition, Optional.of(newPartitionReassignment));
                 });
             });
-            adminClient.alterPartitionReassignments(newReasignement).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+            adminClient.alterPartitionReassignments(newReassignment).all().get();
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to update a Kafka topic partition replication", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to update a Kafka topic partition replication", ex.getMessage());
         }
     }
@@ -161,7 +183,10 @@ public class KafkaService {
     public void updateTopicConfig(Map<ConfigResource, Collection<AlterConfigOp>> configs) {
         try (final AdminClient adminClient = buildAdminClient()) {
             adminClient.incrementalAlterConfigs(configs).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to update a Kafka topic config", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to update a Kafka topic config", ex.getMessage());
         }
     }
@@ -173,7 +198,10 @@ public class KafkaService {
             Map<String, TopicDescription> topicsDescription = getTopicDescription(topics, adminClient);
            log.info("Existing topics retrieved ({})...", topicsDescription.size());
            return topicsDescription;
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to list Kafka topics", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to list Kafka topics", ex.getMessage());
         }
     }
@@ -181,6 +209,9 @@ public class KafkaService {
     public Map<String, TopicDescription> getTopicDescription(Set<String> topics) {
         try (final AdminClient adminClient = buildAdminClient()) {
             return getTopicDescription(topics, adminClient);
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to describe Kafka topics", ex.getMessage());
         } catch (Exception ex) {
             throw new KafkaExecutionException("Error thrown when attempting to describe Kafka topics", ex.getMessage());
         }
@@ -194,7 +225,10 @@ public class KafkaService {
         try (final AdminClient adminClient = buildAdminClient()) {
             List<ConfigResource> resources = topicNames.stream().map(it -> new ConfigResource(ConfigResource.Type.TOPIC, it)).collect(Collectors.toList());
             return adminClient.describeConfigs(resources).all().get();
-        } catch (InterruptedException | ExecutionException ex) {
+        } catch (InterruptedException ex) {
+            Thread.currentThread().interrupt();
+            throw new KafkaExecutionException("Error thrown when attempting to describe a Kafka topic configuration", ex.getMessage());
+        } catch (ExecutionException ex) {
             throw new KafkaExecutionException("Error thrown when attempting to describe a Kafka topic configuration", ex.getMessage());
         }
     }

--- a/src/main/java/com/devshawn/kafka/gitops/service/KafkaService.java
+++ b/src/main/java/com/devshawn/kafka/gitops/service/KafkaService.java
@@ -141,6 +141,9 @@ public class KafkaService {
     }
 
     public void updateTopicReplication(Collection<Node> clusterNodes, String topicName, Integer integer) {
+        if (integer == null || integer < 1) {
+            throw new ValidationException("Replication factor must be a positive integer, got: " + integer);
+        }
         try (final AdminClient adminClient = buildAdminClient()) {
             Map<String, TopicDescription> originalTopicDescription = getTopicDescription(Collections.singleton(topicName), adminClient);
             Map<TopicPartition, Optional<NewPartitionReassignment>> newReassignment = new HashMap<>();

--- a/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
@@ -13,7 +13,7 @@ class PlanCommandIntegrationSpec extends Specification {
     }
 
     void cleanupSpec() {
-//        TestUtils.cleanUpCluster()
+        TestUtils.cleanUpCluster()
     }
 
     void 'test various valid plans - #planName'() {

--- a/src/test/groovy/com/devshawn/kafka/gitops/manager/PlanManagerSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/manager/PlanManagerSpec.groovy
@@ -6,6 +6,7 @@ import com.devshawn.kafka.gitops.domain.plan.DesiredPlan
 import com.devshawn.kafka.gitops.domain.state.DesiredState
 import com.devshawn.kafka.gitops.domain.state.TopicDetails
 import com.devshawn.kafka.gitops.enums.PlanAction
+import com.devshawn.kafka.gitops.exception.ValidationException
 import com.devshawn.kafka.gitops.service.KafkaService
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.apache.kafka.clients.admin.Config
@@ -301,6 +302,37 @@ class PlanManagerSpec extends Specification {
         topicPlan.getTopicConfigPlans().size() == 1
         topicPlan.getTopicConfigPlans().first().getAction() == PlanAction.NO_CHANGE
         topicPlan.getTopicConfigPlans().first().getKey() == 'compression.type'
+    }
+
+    void 'planTopics throws ValidationException when existing topic has empty partition list'() {
+        given:
+        KafkaService kafkaService = new KafkaService(new KafkaGitopsConfig.Builder().putConfig('bootstrap.servers', 'unused').build()) {
+            @Override
+            Map<String, TopicDescription> getTopics() {
+                return ['degraded-topic': new TopicDescription('degraded-topic', false, [])]
+            }
+
+            @Override
+            Map<ConfigResource, Config> describeConfigsForTopics(List<String> topicNames) {
+                return [:]
+            }
+        }
+        PlanManager sut = new PlanManager(managerConfig(), kafkaService, new ObjectMapper())
+        DesiredState desiredState = new DesiredState.Builder()
+                .putTopics('degraded-topic', new TopicDetails.Builder()
+                        .setPartitions(3)
+                        .setReplication(2)
+                        .build())
+                .build()
+        DesiredPlan.Builder desiredPlan = new DesiredPlan.Builder()
+
+        when:
+        sut.planTopics(desiredState, desiredPlan)
+
+        then:
+        ValidationException ex = thrown()
+        ex.message.contains('degraded-topic')
+        ex.message.contains('no available partitions')
     }
 
     void 'planTopics does not describe configs for ignored topics outside desired state'() {

--- a/src/test/groovy/com/devshawn/kafka/gitops/service/KafkaServiceSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/service/KafkaServiceSpec.groovy
@@ -1,5 +1,7 @@
 package com.devshawn.kafka.gitops.service
 
+import com.devshawn.kafka.gitops.config.KafkaGitopsConfig
+import com.devshawn.kafka.gitops.exception.ValidationException
 import spock.lang.Specification
 
 class KafkaServiceSpec extends Specification {
@@ -17,5 +19,46 @@ class KafkaServiceSpec extends Specification {
     void 'describeException falls back to throwable toString when messages are blank'() {
         expect:
         KafkaService.describeException(new RuntimeException('')) == 'java.lang.RuntimeException: '
+    }
+
+    void 'updateTopicReplication throws ValidationException when replication factor is null'() {
+        given:
+        KafkaService sut = new KafkaService(new KafkaGitopsConfig.Builder().putConfig('bootstrap.servers', 'unused').build())
+
+        when:
+        sut.updateTopicReplication([], 'my-topic', null)
+
+        then:
+        ValidationException ex = thrown()
+        ex.message.contains('Replication factor must be a positive integer')
+    }
+
+    void 'updateTopicReplication throws ValidationException when replication factor is #value'() {
+        given:
+        KafkaService sut = new KafkaService(new KafkaGitopsConfig.Builder().putConfig('bootstrap.servers', 'unused').build())
+
+        when:
+        sut.updateTopicReplication([], 'my-topic', value)
+
+        then:
+        ValidationException ex = thrown()
+        ex.message.contains('Replication factor must be a positive integer')
+
+        where:
+        value << [0, -1, -100]
+    }
+
+    void 'addTopicPartition throws IllegalArgumentException when partition count is #value'() {
+        given:
+        KafkaService sut = new KafkaService(new KafkaGitopsConfig.Builder().putConfig('bootstrap.servers', 'unused').build())
+
+        when:
+        sut.addTopicPartition('my-topic', value)
+
+        then:
+        thrown(IllegalArgumentException)
+
+        where:
+        value << [0, -1, -100]
     }
 }


### PR DESCRIPTION
## Summary

Audit-driven fixes for bugs and code quality issues across the core managers and Kafka service layer.

### CRITICAL
- **PlanManager**: Fix `FileWriter` resource leak in `writePlanToFile` — use try-with-resources, remove redundant `createNewFile()` call

### HIGH
- **KafkaService**: Restore thread interrupt flag (`Thread.currentThread().interrupt()`) in all 10 `InterruptedException` catch sites — previously swallowed, breaking cooperative cancellation
- **KafkaService**: `updateTopicReplication` now reuses the existing `AdminClient` via the private overload instead of opening a second connection
- **ApplyManager**: Skip `NO_CHANGE` topic config plans in both `applyTopics` and `applyStaleAddTopic` — previously fired spurious `incrementalAlterConfigs` API calls per unchanged config per topic
- **StateManager**: Replace `orElseGet(defaultPartitions::get)` / `orElseGet(defaultReplication::get)` with `.or() + orElseThrow()` — gives a clear `ValidationException` instead of `NoSuchElementException`
- **PlanManager**: Guard against empty partition list before `.get(0)` — throws `ValidationException` with context instead of bare `IndexOutOfBoundsException`

### MEDIUM / LOW
- `addTopicPartition` guard fixed: `<= 1` → `< 1`
- Typos fixed: `increate` → `increase`, `enougth` → `enough`, `newReasignement` → `newReassignment`
- All three static loggers made `final`
- `PlanCommandIntegrationSpec.cleanupSpec`: uncomment `cleanUpCluster()` to prevent cluster state leaks between test runs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes correctness issues across managers and the Kafka service. Restores proper cancellation, removes unnecessary admin/config calls, adds stricter validation, and plugs a file writer leak.

- **Bug Fixes**
  - Restore thread interrupt flag in Kafka service on all InterruptedException catch sites.
  - Reuse existing AdminClient in topic replication updates; no second connection.
  - Validate replication factor is non-null and >= 1 before reassignment in updateTopicReplication.
  - Skip NO_CHANGE topic config plans in apply and stale-add paths to avoid unnecessary incrementalAlterConfigs calls.
  - Fix partition count guard in addTopicPartition to reject < 1; improve error text.
  - Guard against empty partition lists during planning; throw ValidationException with context.

- **Refactors**
  - Use try-with-resources when writing plan files; remove redundant createNewFile() to prevent leaks.
  - Emit clearer ValidationExceptions for missing partitions/replication defaults in StateManager.
  - Make static loggers final, fix typos, re-enable test cluster cleanup; add CHANGELOG.md following Keep a Changelog.

<sup>Written for commit 5bf58f1eb2f98e40893f7edb25b03aaa8ef9c582. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened validation for topic partitions and replication to prevent invalid topic states and improve related error messages.
  * Improved exception handling across Kafka operations for more reliable failure reporting and proper thread interruption.

* **Tests**
  * Ensured test cluster cleanup runs after integration specs.
  * Added tests covering partition/replication validation and related error conditions.

* **Documentation**
  * Updated CHANGELOG with an Unreleased v0.5.2 entry summarizing fixes and tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/kafka-gitops/pull/49)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->