### PR TITLE
test: stabilize stale-add test for Kafka 4.0 (ISR wait)

### DIFF
--- a/src/test/groovy/com/devshawn/kafka/gitops/TestUtils.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/TestUtils.groovy
@@ -148,6 +148,16 @@ class TestUtils {
                 return "Topic ${name} is not visible yet: ${ex.message}"
             }
         }
+        waitForCleanup("topic ${name} to have stable ISR") {
+            try {
+                def descriptions = waitFor(adminClient.describeTopics(Collections.singleton(name)).allTopicNames())
+                def partitionInfos = descriptions[name].partitions()
+                def unstable = partitionInfos.findAll { it.isr().size() < it.replicas().size() }
+                return unstable.isEmpty() ? null : "Topic ${name} has partitions with incomplete ISR: ${unstable.collect { it.partition() }}"
+            } catch (Exception ex) {
+                return "Error checking ISR stability for ${name}: ${ex.message}"
+            }
+        }
     }
 
     static void createAcl(AdminClient adminClient) {

--- a/src/test/groovy/com/devshawn/kafka/gitops/TestUtils.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/TestUtils.groovy
@@ -148,6 +148,10 @@ class TestUtils {
                 return "Topic ${name} is not visible yet: ${ex.message}"
             }
         }
+        // Wait for all partition replicas to join the ISR before returning.
+        // Uses the full CLEANUP_ATTEMPTS budget (not TOPIC_STABILITY_CHECKS) because ISR
+        // convergence under Kafka 4.0 KRaft CI can take longer than the 3×500ms stability check.
+        // On a healthy cluster the first attempt succeeds immediately.
         waitForCleanup("topic ${name} to have stable ISR") {
             try {
                 def descriptions = waitFor(adminClient.describeTopics(Collections.singleton(name)).allTopicNames())


### PR DESCRIPTION
## Problem

The `test stale add plan applies successfully when topic already exists` test was flaky on the kafka40 matrix. The apply command returned exit code 2 (caught exception) when trying to increase partitions on a freshly-created topic.

**Root cause**: `TestUtils.createTopic` waited for topic visibility (describable) but not ISR stability. On Kafka 4.0 with `MIN_INSYNC_REPLICAS=2` and `replication_factor=2`, calling `createPartitions` before all replicas are in the ISR can fail at the broker level. The main branch CI and tag CI ran the same commit in parallel — one happened to pass before ISR stabilized, the other hit the race window.

## Fix

Add a second `waitForCleanup` step in `createTopic` that polls until all partitions report `isr.size() == replicas.size()`. Uses the same polling infrastructure as the rest of `TestUtils` (30 attempts × 2s).

## Affected

`TestUtils.createTopic` — all callers benefit, including `seedCluster` and the stale-add test.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes the Kafka 4.0 stale-add test by waiting for ISR to be fully in-sync before returning from topic creation. Uses the full cleanup polling budget to avoid races, fixing `createPartitions` failures on fresh topics.

- **Bug Fixes**
  - In `TestUtils.createTopic`, wait until all partitions have full ISR (`isr.size() == replicas.size()`).
  - Use the full cleanup budget (30 attempts × 2s) instead of short stability checks, since ISR convergence can take longer on Kafka 4.0 KRaft CI.
  - Prevents broker errors in `createPartitions` with `MIN_INSYNC_REPLICAS=2` and replication factor 2.
  - Affects all callers, including `seedCluster` and the stale-add test.

<sup>Written for commit 3eea92ca49e0d97fc024fad5f1e0c760fa1bdb4a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test topic-creation utility to wait until all partitions reach stable replica states before completing. Adds retry logic for robustness during initialization and surfaces clear error messages when partitions remain incomplete or when metadata lookups fail.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/kafka-gitops/pull/50)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->