### PR TITLE
test: cover prefixed topic delete ACLs

### DIFF
--- a/src/test/groovy/com/devshawn/kafka/gitops/ApplyCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/ApplyCommandIntegrationSpec.groovy
@@ -45,6 +45,7 @@ class ApplyCommandIntegrationSpec extends Specification {
                 "simple-users",
                 "custom-service-acls",
                 "custom-user-acls",
+                "custom-user-prefixed-topic-delete-acls",
                 "custom-group-id-application",
                 "custom-group-id-connect",
                 "custom-application-id-streams",

--- a/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
@@ -50,6 +50,7 @@ class PlanCommandIntegrationSpec extends Specification {
                 "simple-users",
                 "custom-service-acls",
                 "custom-user-acls",
+                "custom-user-prefixed-topic-delete-acls",
                 "custom-group-id-application",
                 "custom-group-id-connect",
                 "custom-application-id-streams",

--- a/src/test/groovy/com/devshawn/kafka/gitops/domain/state/CustomAclDetailsSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/domain/state/CustomAclDetailsSpec.groovy
@@ -32,6 +32,7 @@ class CustomAclDetailsSpec extends Specification {
         where:
         type                        | pattern                     | operation                    | permission
         ResourceType.TOPIC.name()   | PatternType.LITERAL.name()  | AclOperation.READ.name()     | AclPermissionType.ALLOW.name()
+        ResourceType.TOPIC.name()   | PatternType.PREFIXED.name() | AclOperation.DELETE.name()   | AclPermissionType.ALLOW.name()
         ResourceType.CLUSTER.name() | PatternType.PREFIXED.name() | AclOperation.WRITE.name()    | AclPermissionType.DENY.name()
         ResourceType.GROUP.name()   | PatternType.LITERAL.name()  | AclOperation.CREATE.name()   | AclPermissionType.ALLOW.name()
         ResourceType.GROUP.name()   | PatternType.LITERAL.name()  | AclOperation.DESCRIBE.name() | AclPermissionType.DENY.name()

--- a/src/test/resources/plans/custom-user-prefixed-topic-delete-acls-apply-output.txt
+++ b/src/test/resources/plans/custom-user-prefixed-topic-delete-acls-apply-output.txt
@@ -1,0 +1,101 @@
+Executing apply...
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-0
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: CREATE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-1
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: WRITE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-2
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: READ
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-3
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: DESCRIBE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-4
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: ALTER_CONFIGS
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-5
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: DESCRIBE_CONFIGS
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+Applying: [CREATE]
+
++ [ACL] topic-reset-user-6
+	 + resource_name: events_reset_
+	 + resource_type: TOPIC
+	 + resource_pattern: PREFIXED
+	 + resource_principal: User:topic-reset
+	 + host: *
+	 + operation: DELETE
+	 + permission: ALLOW
+
+
+Successfully applied.
+
+[SUCCESS] Apply complete! Resources: 7 created, 0 updated, 0 deleted.

--- a/src/test/resources/plans/custom-user-prefixed-topic-delete-acls-plan.json
+++ b/src/test/resources/plans/custom-user-prefixed-topic-delete-acls-plan.json
@@ -1,0 +1,96 @@
+{
+    "topicPlans": [],
+    "aclPlans": [
+        {
+            "name": "topic-reset-user-0",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "CREATE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-1",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "WRITE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-2",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "READ",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-3",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "DESCRIBE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-4",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "ALTER_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-5",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "DESCRIBE_CONFIGS",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        },
+        {
+            "name": "topic-reset-user-6",
+            "aclDetails": {
+                "name": "events_reset_",
+                "type": "TOPIC",
+                "pattern": "PREFIXED",
+                "principal": "User:topic-reset",
+                "host": "*",
+                "operation": "DELETE",
+                "permission": "ALLOW"
+            },
+            "action": "ADD"
+        }
+    ]
+}

--- a/src/test/resources/plans/custom-user-prefixed-topic-delete-acls.yaml
+++ b/src/test/resources/plans/custom-user-prefixed-topic-delete-acls.yaml
@@ -1,0 +1,55 @@
+users:
+  topic-reset-user:
+    principal: User:topic-reset
+
+customUserAcls:
+  topic-reset-user:
+    create-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: CREATE
+      permission: ALLOW
+    write-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: WRITE
+      permission: ALLOW
+    read-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: READ
+      permission: ALLOW
+    describe-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: DESCRIBE
+      permission: ALLOW
+    alter-configs-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: ALTER_CONFIGS
+      permission: ALLOW
+    describe-configs-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: DESCRIBE_CONFIGS
+      permission: ALLOW
+    delete-prefixed-topics:
+      name: events_reset_
+      type: TOPIC
+      pattern: PREFIXED
+      host: "*"
+      operation: DELETE
+      permission: ALLOW


### PR DESCRIPTION
## Summary

- Add a focused custom user ACL fixture for prefixed topic lifecycle permissions, including DELETE.
- Cover the fixture in plan and apply integration specs.
- Explicitly validate TOPIC/PREFIXED/DELETE as an accepted custom ACL combination.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a focused test fixture and integration specs for prefixed topic ACLs, including DELETE. Confirms that TOPIC + PREFIXED + DELETE is accepted as a valid custom ACL and adds the `custom-user-prefixed-topic-delete-acls` case to plan/apply tests.

<sup>Written for commit ce7a8b8c17fd225452e82371c6945b7ec323b459. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/kafka-gitops/pull/53?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for custom ACL scenarios with prefixed topic patterns and DELETE operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/kafka-gitops/pull/53?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->