### PR TITLE
fix: reject match custom ACL patterns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2026-05-26
+
+### Fixed
+- Reject `MATCH` as a custom ACL desired-state pattern. Kafka supports `MATCH` for ACL filters, but concrete ACLs can only be created with `LITERAL` or `PREFIXED` patterns.
+
+### Documentation
+- Clarify that `PREFIXED` topic ACLs grant Kafka permissions but do not change topic reconciliation; unmanaged matching topics still need `settings.topics.blacklist.prefixed`, `settings.topics.whitelist.prefixed`, or `--no-delete` when deletion planning is not intended.
+
 ## [0.5.2] - 2026-05-12
 
 ### Fixed
@@ -68,7 +76,9 @@ See [0.3.0...0.3.1](https://github.com/chenrui333/kafka-gitops/compare/0.3.0...0
 
 Initial tracked release.
 
-[Unreleased]: https://github.com/chenrui333/kafka-gitops/compare/0.5.1...HEAD
+[Unreleased]: https://github.com/chenrui333/kafka-gitops/compare/0.5.3...HEAD
+[0.5.3]: https://github.com/chenrui333/kafka-gitops/compare/0.5.2...0.5.3
+[0.5.2]: https://github.com/chenrui333/kafka-gitops/compare/0.5.1...0.5.2
 [0.5.1]: https://github.com/chenrui333/kafka-gitops/compare/0.5.0...0.5.1
 [0.5.0]: https://github.com/chenrui333/kafka-gitops/compare/0.4.0...0.5.0
 [0.4.0]: https://github.com/chenrui333/kafka-gitops/compare/0.3.1...0.4.0

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -266,6 +266,8 @@ customServiceAcls:
 
     When using Confluent Cloud, the `customServiceAcls` key must still match a service defined under `services`, and that service name must match the existing Confluent Cloud service account name. The `principal` value in the custom ACL is ignored and replaced with the live service-account ID.
 
+    Custom ACL `pattern` values are limited to `LITERAL` and `PREFIXED`. Kafka's `MATCH` pattern is only valid for ACL filters and cannot be created as a concrete ACL.
+
 ## Custom User ACLs
 
 **Synopsis**: Define custom ACLs for a specific user. 
@@ -289,3 +291,7 @@ customUserAcls:
 !!! note
 
     The `principal` field can be omitted here and will be inherited from the user definition.
+
+    Custom ACL `pattern` values are limited to `LITERAL` and `PREFIXED`. Kafka's `MATCH` pattern is only valid for ACL filters and cannot be created as a concrete ACL.
+
+    A `PREFIXED` topic ACL grants permissions for matching Kafka topics, but it does not change topic reconciliation. If matching topics are created outside your desired state file, protect them with `settings.topics.blacklist.prefixed`, limit management with `settings.topics.whitelist.prefixed`, or run `plan`/`apply` with `--no-delete` when deletion planning is not intended.

--- a/release-notes/0.5.3.md
+++ b/release-notes/0.5.3.md
@@ -1,0 +1,11 @@
+## Highlights
+
+Custom ACL validation now rejects `MATCH` as a desired-state pattern before Kafka apply work begins. This prevents state files from validating successfully and then failing at ACL creation time, because Kafka only allows `MATCH` for ACL filters, not concrete ACLs.
+
+## Fixed
+
+- Reject `MATCH` in `customServiceAcls` and `customUserAcls` pattern validation. Use `PREFIXED` for topic-prefix ACLs, such as granting `DELETE` on topics beginning with `rna_cdc_`.
+
+## Documentation
+
+- Clarify that `PREFIXED` topic ACLs grant Kafka permissions but do not change topic reconciliation. If matching topics are created outside the desired state file, protect them with `settings.topics.blacklist.prefixed`, limit management with `settings.topics.whitelist.prefixed`, or run `plan`/`apply` with `--no-delete` when deletion planning is not intended.

--- a/src/main/java/com/devshawn/kafka/gitops/domain/state/CustomAclDetails.java
+++ b/src/main/java/com/devshawn/kafka/gitops/domain/state/CustomAclDetails.java
@@ -16,6 +16,8 @@ import java.util.stream.Collectors;
 @FreeBuilder
 @JsonDeserialize(builder = CustomAclDetails.Builder.class)
 public abstract class CustomAclDetails {
+    private static final List<String> DEFAULT_EXCLUDED_ENUM_VALUES = List.of("ANY", "UNKNOWN");
+    private static final List<String> PATTERN_EXCLUDED_ENUM_VALUES = List.of("ANY", "UNKNOWN", "MATCH");
 
     public abstract String getName();
 
@@ -33,13 +35,20 @@ public abstract class CustomAclDetails {
 
     public void validate() {
         validateEnum(ResourceType.class, getType(), "type");
-        validateEnum(PatternType.class, getPattern(), "pattern");
+        validateEnum(PatternType.class, getPattern(), "pattern", PATTERN_EXCLUDED_ENUM_VALUES);
         validateEnum(AclOperation.class, getOperation(), "operation");
         validateEnum(AclPermissionType.class, getPermission(), "permission");
     }
 
     private <E extends Enum<E>> void validateEnum(Class<E> enumData, String value, String field) {
-        List<String> allowedValues = Arrays.stream(enumData.getEnumConstants()).map(Enum::name).filter(it -> !it.equals("ANY") && !it.equals("UNKNOWN")).collect(Collectors.toList());
+        validateEnum(enumData, value, field, DEFAULT_EXCLUDED_ENUM_VALUES);
+    }
+
+    private <E extends Enum<E>> void validateEnum(Class<E> enumData, String value, String field, List<String> excludedValues) {
+        List<String> allowedValues = Arrays.stream(enumData.getEnumConstants())
+                .map(Enum::name)
+                .filter(it -> !excludedValues.contains(it))
+                .collect(Collectors.toList());
         if (!allowedValues.contains(value)) {
             throw new InvalidAclDefinitionException(field, value, allowedValues);
         }

--- a/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/PlanCommandIntegrationSpec.groovy
@@ -212,7 +212,8 @@ class PlanCommandIntegrationSpec extends Specification {
                 "invalid-topic-whitelist",
                 "invalid-default-replication-1",
                 "invalid-default-replication-2",
-                "invalid-topic-remove-partitions"
+                "invalid-topic-remove-partitions",
+                "invalid-custom-user-acls-match-pattern"
         ]
     }
 

--- a/src/test/groovy/com/devshawn/kafka/gitops/ValidateCommandIntegrationSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/ValidateCommandIntegrationSpec.groovy
@@ -63,7 +63,8 @@ class ValidateCommandIntegrationSpec extends Specification {
                 "invalid-custom-service-acls-1",
                 "invalid-custom-service-acls-2",
                 "invalid-custom-user-acls-1",
-                "invalid-custom-user-acls-2"
+                "invalid-custom-user-acls-2",
+                "invalid-custom-user-acls-match-pattern"
         ]
     }
 }

--- a/src/test/groovy/com/devshawn/kafka/gitops/domain/state/CustomAclDetailsSpec.groovy
+++ b/src/test/groovy/com/devshawn/kafka/gitops/domain/state/CustomAclDetailsSpec.groovy
@@ -82,10 +82,10 @@ class CustomAclDetailsSpec extends Specification {
         InvalidAclDefinitionException ex = thrown(InvalidAclDefinitionException)
         ex.getField() == "pattern"
         ex.getValue() == input
-        ex.getAllowedValues() == ["MATCH", "LITERAL", "PREFIXED"]
+        ex.getAllowedValues() == ["LITERAL", "PREFIXED"]
 
         where:
-        input << ["ANY", "UNKNOWN", "not real", "PREFIX", "prefixed", "topic"]
+        input << ["ANY", "UNKNOWN", "MATCH", "not real", "PREFIX", "prefixed", "topic"]
     }
 
     void 'test invalid custom acl details - operation - #input'() {

--- a/src/test/resources/plans/invalid-custom-service-acls-1-validate-output.txt
+++ b/src/test/resources/plans/invalid-custom-service-acls-1-validate-output.txt
@@ -1,1 +1,1 @@
-[INVALID] Custom ACL definition for service 'test-service' is invalid for field 'pattern'. Allowed values: [MATCH, LITERAL, PREFIXED]
+[INVALID] Custom ACL definition for service 'test-service' is invalid for field 'pattern'. Allowed values: [LITERAL, PREFIXED]

--- a/src/test/resources/plans/invalid-custom-user-acls-match-pattern-output.txt
+++ b/src/test/resources/plans/invalid-custom-user-acls-match-pattern-output.txt
@@ -1,1 +1,3 @@
+Generating execution plan...
+
 [INVALID] Custom ACL definition for user 'test-user' is invalid for field 'pattern'. Allowed values: [LITERAL, PREFIXED]

--- a/src/test/resources/plans/invalid-custom-user-acls-match-pattern-output.txt
+++ b/src/test/resources/plans/invalid-custom-user-acls-match-pattern-output.txt
@@ -1,0 +1,1 @@
+[INVALID] Custom ACL definition for user 'test-user' is invalid for field 'pattern'. Allowed values: [LITERAL, PREFIXED]

--- a/src/test/resources/plans/invalid-custom-user-acls-match-pattern-validate-output.txt
+++ b/src/test/resources/plans/invalid-custom-user-acls-match-pattern-validate-output.txt
@@ -1,0 +1,1 @@
+[INVALID] Custom ACL definition for user 'test-user' is invalid for field 'pattern'. Allowed values: [LITERAL, PREFIXED]

--- a/src/test/resources/plans/invalid-custom-user-acls-match-pattern.yaml
+++ b/src/test/resources/plans/invalid-custom-user-acls-match-pattern.yaml
@@ -1,0 +1,13 @@
+users:
+  test-user:
+    principal: User:test
+
+customUserAcls:
+  test-user:
+    delete-rna-cdc-topics:
+      name: rna_cdc_
+      type: TOPIC
+      pattern: MATCH
+      host: "*"
+      operation: DELETE
+      permission: ALLOW


### PR DESCRIPTION
## Summary

- Reject Kafka `MATCH` for custom ACL desired-state patterns and keep allowed values to `LITERAL`/`PREFIXED`
- Add validate/plan regression coverage for a prefixed topic DELETE ACL using invalid `MATCH`
- Document concrete custom ACL pattern values and the topic reconciliation caveat for prefixed ACLs

## Notes

Kafka accepts `MATCH` for ACL filters, but not for concrete ACL creation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject Kafka `MATCH` for custom ACL patterns; only `LITERAL` and `PREFIXED` are allowed. Adds clear validation errors, updates docs/release notes, and clarifies that `PREFIXED` topic ACLs do not affect topic reconciliation.

- **Bug Fixes**
  - Validate and reject `MATCH` for custom ACL `pattern` in `customServiceAcls` and `customUserAcls`.
  - Added plan/validate tests for invalid `MATCH`; updated outputs to show allowed values: `LITERAL`, `PREFIXED`.
  - Updated docs and 0.5.3 release notes to document allowed patterns and note that `PREFIXED` topic ACLs don’t change reconciliation behavior.

- **Migration**
  - If any custom ACLs use `MATCH`, switch them to `LITERAL` or `PREFIXED`.

<sup>Written for commit bec91f37ce6f447623541cfcb3b8d1efc715dacd. Summary will update on new commits. <a href="https://cubic.dev/pr/chenrui333/kafka-gitops/pull/54?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted ACL pattern configuration to `LITERAL` and `PREFIXED` values; `MATCH` patterns are no longer supported.

* **Documentation**
  * Updated specification documentation clarifying ACL pattern limitations and guidance for `customUserAcls` configuration alternatives.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chenrui333/kafka-gitops/pull/54?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->